### PR TITLE
feat(#2): Add Schedule Tab to Settings — Break Time, Wait Time & Notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+*.class
+

--- a/src/AppTray.java
+++ b/src/AppTray.java
@@ -1,8 +1,9 @@
 import java.awt.*;
 import java.awt.image.BufferedImage;
-import javax.swing.JOptionPane;
 
 public class AppTray {
+
+    public static TrayIcon trayIcon;
 
     public static void setupTray() {
         if (!SystemTray.isSupported()) {
@@ -33,7 +34,7 @@ public class AppTray {
         popup.add(settingsItem);
         popup.add(exitItem);
 
-        TrayIcon trayIcon = new TrayIcon(iconImage, "EyeSoft", popup);
+        trayIcon = new TrayIcon(iconImage, "EyeSoft", popup);
         trayIcon.setImageAutoSize(true);
 
         try {

--- a/src/Main.java
+++ b/src/Main.java
@@ -4,18 +4,19 @@
 import java.util.concurrent.*;
 
 import java.io.IOException;
+import java.awt.TrayIcon;
 
 import java.util.prefs.Preferences;
 
 
 public class Main {
 
-//    public static int waitSeconds = ;
-
     static Preferences prefs = Preferences.userNodeForPackage(Main.class);
     public static int waitSeconds = prefs.getInt("savedWaitTime", 30);
-    private static ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
-    private static ScheduledFuture<?> scheduledTask;
+    public static int breakSeconds = prefs.getInt("savedBreakTime", 20);
+    
+    private static ExecutorService executor = Executors.newSingleThreadExecutor();
+    private static Future<?> currentTask;
 
     void main() {
         AppTray.setupTray();
@@ -24,57 +25,55 @@ public class Main {
 
     public static void startT() {
 
-        if (scheduledTask != null && !scheduledTask.isCancelled()) {
-            scheduledTask.cancel(false);
+        if (currentTask != null && !currentTask.isDone()) {
+            currentTask.cancel(true);
         }
 
-        Runnable blockingTask = () -> {
-
-            Process process = null;
-
+        currentTask = executor.submit(() -> {
             try {
+                // First wait happens before the first break. We'll start with waiting.
+                while (!Thread.currentThread().isInterrupted()) {
+                    
+                    int notifyAdvance = Math.min(10, waitSeconds / 2); // 10 secs or half the wait
+                    int initialWait = waitSeconds - notifyAdvance;
 
+                    if (initialWait > 0) {
+                        Thread.sleep(initialWait * 1000L);
+                    }
 
-                //Below Is for Frontend People
-                //Basically it just import code from screen blocker (UI)
-                // Please Contact Me Before Edit UI Pleaseeeeeee
-                String screenblockpath = System.getProperty("java.class.path");
-                ProcessBuilder processBuilder = new ProcessBuilder("java","-Dapple.awt.UIElement=true", "-cp", screenblockpath, "ScreenBlocker");
-                //-Dapple.awt.UIElement --> Docker Icon Remove
-                processBuilder.inheritIO();
+                    if (notifyAdvance > 0) {
+                        if (AppTray.trayIcon != null) {
+                            AppTray.trayIcon.displayMessage("Upcoming Break", "Your break will start in " + notifyAdvance + " seconds.", TrayIcon.MessageType.INFO);
+                        }
+                        Thread.sleep(notifyAdvance * 1000L);
+                    }
 
+                    Process process = null;
+                    try {
+                        //Start ScreenBlocker
+                        String screenblockpath = System.getProperty("java.class.path");
+                        ProcessBuilder processBuilder = new ProcessBuilder("java", "-Dapple.awt.UIElement=true", "-cp", screenblockpath, "ScreenBlocker");
+                        processBuilder.inheritIO();
+                        process = processBuilder.start();
 
-                process = processBuilder.start();
-
-                Thread.sleep(5000);
-                // Above Code --> Who Much Time Should It have the Screen Blocker
-                // 1 Second = 1000 ms
-                // We need to make it adjusted from settings
-            } catch (IOException | InterruptedException e) {
-                e.printStackTrace();
-                Thread.currentThread().interrupt();
-            } finally {
-                if (process != null && process.isAlive()) {
-                    process.destroy();
+                        Thread.sleep(breakSeconds * 1000L);
+                    } finally {
+                        if (process != null && process.isAlive()) {
+                            process.destroy();
+                        }
+                    }
                 }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (IOException e) {
+                e.printStackTrace();
             }
-        };
-
-        
-
-        scheduler.scheduleWithFixedDelay(blockingTask, waitSeconds, waitSeconds, TimeUnit.SECONDS);
-        //In Brackets
-        //2) After how much time the application run
-        //(Basically after User Open App after how many seconds will Screen Blocker appear first)
-
-        //3) After 1st Block Done - Above One Thread.sleep( ms ) in above part
-        //The delay for next block screen
+        });
 
     }
 
-
-        public static void shutdown () {
-            scheduler.shutdownNow();
-            System.exit(0);
-        }
+    public static void shutdown () {
+        executor.shutdownNow();
+        System.exit(0);
+    }
 }

--- a/src/Settings.java
+++ b/src/Settings.java
@@ -29,42 +29,42 @@ public class Settings {
         frame.setAlwaysOnTop(true);
 
         JTabbedPane tabbedPane = new JTabbedPane();
-        JPanel timingPanel = new JPanel(new FlowLayout(FlowLayout.CENTER, 10, 20));
+        JPanel timingPanel = new JPanel(new GridLayout(3, 2, 10, 10));
+        timingPanel.setBorder(BorderFactory.createEmptyBorder(20, 20, 20, 20));
 
+        JLabel waitLabel = new JLabel("Wait Time (seconds):");
+        JTextField waitTimeField = new JTextField(String.valueOf(Main.waitSeconds), 5);
 
+        JLabel breakLabel = new JLabel("Break Time (seconds):");
+        JTextField breakTimeField = new JTextField(String.valueOf(Main.breakSeconds), 5);
 
-        JLabel label = new JLabel("Wait");
-        // Above is Add Wait Time. Fix UI
-
-
-
-        JTextField timeField = new JTextField(String.valueOf(Main.waitSeconds), 5);
         JButton saveButton = new JButton("Save");
-        //Save Btn Fix UI
-
         saveButton.addActionListener(e -> {
             try {
-                int newWait = Integer.parseInt(timeField.getText().trim());
-
+                int newWait = Integer.parseInt(waitTimeField.getText().trim());
+                int newBreak = Integer.parseInt(breakTimeField.getText().trim());
 
                 Main.waitSeconds = newWait;
-
+                Main.breakSeconds = newBreak;
 
                 Preferences prefs = Preferences.userNodeForPackage(Main.class);
                 prefs.putInt("savedWaitTime", newWait);
+                prefs.putInt("savedBreakTime", newBreak);
                 Main.startT();
 
                 frame.dispose();
             } catch (NumberFormatException ex) {
-                JOptionPane.showMessageDialog(frame, "Valid No");
-                //Setting Wrror
+                JOptionPane.showMessageDialog(frame, "Please enter valid numbers for both fields.", "Input Error", JOptionPane.ERROR_MESSAGE);
+                //Setting Error
             }
         });
 
-        timingPanel.add(label);
-        timingPanel.add(timeField);
+        timingPanel.add(waitLabel);
+        timingPanel.add(waitTimeField);
+        timingPanel.add(breakLabel);
+        timingPanel.add(breakTimeField);
+        timingPanel.add(new JLabel("")); // Empty cell for alignment
         timingPanel.add(saveButton);
-        timingPanel.setVisible(true);
 
         JPanel aboutPanel = new JPanel(new BorderLayout());
 

--- a/src/main/java/com/eyesoft/AppTray.java
+++ b/src/main/java/com/eyesoft/AppTray.java
@@ -3,47 +3,77 @@ package com.eyesoft;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 
+/**
+ * AppTray — System tray icon and menu.
+ * All errors logged with EyeLogger context.
+ */
 public class AppTray {
 
     public static TrayIcon trayIcon;
 
     public static void setupTray() {
+        EyeLogger.info("AppTray", "Initializing system tray");
+
         if (!SystemTray.isSupported()) {
+            EyeLogger.warn("AppTray", "SystemTray not supported on this platform — tray icon skipped");
             return;
         }
 
-
-        //Tray UI
-        BufferedImage iconImage = new BufferedImage(16, 16, BufferedImage.TYPE_INT_RGB);
-        Graphics g = iconImage.getGraphics();
-        g.setColor(Color.RED);
-        g.fillRect(0, 0, 16, 16);
-
-        PopupMenu popup = new PopupMenu();
-
-        // Menu
-        MenuItem settingsItem = new MenuItem("Time");
-        settingsItem.addActionListener(e -> {
-
-            Settings.showWindow();
-        });
-
-        MenuItem exitItem = new MenuItem("Exit");
-        exitItem.addActionListener(e -> {
-            Main.shutdown();
-        });
-
-        popup.add(settingsItem);
-        popup.add(exitItem);
-
-        trayIcon = new TrayIcon(iconImage, "EyeSoft", popup);
-        trayIcon.setImageAutoSize(true);
-
         try {
+            // ── Tray icon image (red square)
+            BufferedImage iconImage = new BufferedImage(16, 16, BufferedImage.TYPE_INT_RGB);
+            Graphics g = iconImage.getGraphics();
+            g.setColor(Color.RED);
+            g.fillRect(0, 0, 16, 16);
+            g.dispose();
+
+            // ── Popup menu
+            PopupMenu popup = new PopupMenu();
+
+            MenuItem settingsItem = new MenuItem("Time");
+            settingsItem.addActionListener(e -> {
+                EyeLogger.info("AppTray", "User opened Settings from tray");
+                try {
+                    Settings.showWindow();
+                } catch (Exception ex) {
+                    EyeLogger.error("AppTray", "Failed to open Settings window", ex);
+                }
+            });
+
+            MenuItem exitItem = new MenuItem("Exit");
+            exitItem.addActionListener(e -> {
+                EyeLogger.info("AppTray", "User requested exit from tray");
+                try {
+                    Main.shutdown();
+                } catch (Exception ex) {
+                    EyeLogger.error("AppTray", "Error during shutdown from tray", ex);
+                    System.exit(1);
+                }
+            });
+
+            popup.add(settingsItem);
+            popup.add(exitItem);
+
+            trayIcon = new TrayIcon(iconImage, "EyeSoft", popup);
+            trayIcon.setImageAutoSize(true);
+
+            // Double-click on tray icon also opens settings
+            trayIcon.addActionListener(e -> {
+                EyeLogger.info("AppTray", "Tray icon double-clicked — opening Settings");
+                try {
+                    Settings.showWindow();
+                } catch (Exception ex) {
+                    EyeLogger.error("AppTray", "Failed to open Settings on tray double-click", ex);
+                }
+            });
+
             SystemTray.getSystemTray().add(trayIcon);
+            EyeLogger.info("AppTray", "Tray icon added successfully");
+
         } catch (AWTException e) {
-            System.err.println("Tray Error");
+            EyeLogger.error("AppTray", "Failed to add tray icon to SystemTray", e);
+        } catch (Exception e) {
+            EyeLogger.error("AppTray", "Unexpected error during tray setup", e);
         }
     }
-
 }

--- a/src/main/java/com/eyesoft/AppTray.java
+++ b/src/main/java/com/eyesoft/AppTray.java
@@ -1,3 +1,5 @@
+package com.eyesoft;
+
 import java.awt.*;
 import java.awt.image.BufferedImage;
 

--- a/src/main/java/com/eyesoft/EyeLogger.java
+++ b/src/main/java/com/eyesoft/EyeLogger.java
@@ -1,0 +1,70 @@
+package com.eyesoft;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.logging.*;
+
+/**
+ * EyeLogger — Centralized, context-aware application logger.
+ * Logs to both console (ANSI-colored) and a rotating file log.
+ */
+public class EyeLogger {
+
+    private static final Logger LOGGER = Logger.getLogger("EyeSoft");
+    private static final DateTimeFormatter FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    static {
+        try {
+            LOGGER.setUseParentHandlers(false);
+
+            // Console handler with simple formatting
+            ConsoleHandler ch = new ConsoleHandler();
+            ch.setFormatter(new SimpleFormatter() {
+                @Override
+                public synchronized String format(LogRecord lr) {
+                    String time = LocalDateTime.now().format(FMT);
+                    String level = lr.getLevel().getName();
+                    String msg = lr.getMessage();
+                    String prefix = level.equals("SEVERE") ? "[ERROR]" :
+                                    level.equals("WARNING") ? "[WARN] " : "[INFO] ";
+                    return time + " " + prefix + " " + msg + "\n";
+                }
+            });
+            ch.setLevel(Level.ALL);
+            LOGGER.addHandler(ch);
+
+            // File handler
+            FileHandler fh = new FileHandler(
+                System.getProperty("user.home") + "/Library/Logs/EyeSoft.log",
+                1_000_000, 3, true  // 1 MB, 3 rotating files, append
+            );
+            fh.setFormatter(new SimpleFormatter());
+            fh.setLevel(Level.ALL);
+            LOGGER.addHandler(fh);
+
+            LOGGER.setLevel(Level.ALL);
+        } catch (Exception e) {
+            // Fallback: let JUL use defaults if file logger fails
+            System.err.println("[EyeLogger] Failed to init file logger: " + e.getMessage());
+        }
+    }
+
+    // ── Public API ──────────────────────────────────────────────────────────────
+
+    public static void info(String context, String msg) {
+        LOGGER.info("[" + context + "] " + msg);
+    }
+
+    public static void warn(String context, String msg) {
+        LOGGER.warning("[" + context + "] " + msg);
+    }
+
+    public static void error(String context, String msg, Throwable t) {
+        LOGGER.log(Level.SEVERE, "[" + context + "] " + msg +
+            (t != null ? " | " + t.getClass().getSimpleName() + ": " + t.getMessage() : ""), t);
+    }
+
+    public static void error(String context, String msg) {
+        error(context, msg, null);
+    }
+}

--- a/src/main/java/com/eyesoft/Main.java
+++ b/src/main/java/com/eyesoft/Main.java
@@ -1,6 +1,8 @@
 //import java.util.concurrent.Executors;
 //import java.util.concurrent.ScheduledExecutorService;
 //import java.util.concurrent.TimeUnit;
+package com.eyesoft;
+
 import java.util.concurrent.*;
 
 import java.io.IOException;
@@ -52,7 +54,7 @@ public class Main {
                     try {
                         //Start ScreenBlocker
                         String screenblockpath = System.getProperty("java.class.path");
-                        ProcessBuilder processBuilder = new ProcessBuilder("java", "-Dapple.awt.UIElement=true", "-cp", screenblockpath, "ScreenBlocker");
+                        ProcessBuilder processBuilder = new ProcessBuilder("java", "-Dapple.awt.UIElement=true", "-cp", screenblockpath, "com.eyesoft.ScreenBlocker");
                         processBuilder.inheritIO();
                         process = processBuilder.start();
 

--- a/src/main/java/com/eyesoft/Main.java
+++ b/src/main/java/com/eyesoft/Main.java
@@ -22,8 +22,15 @@ public class Main {
     private static Future<?> currentTask;
 
     public static void main(String[] args) {
-        AppTray.setupTray();
-        startT();
+        EyeLogger.info("Main", "EyeSoft starting up");
+        try {
+            AppTray.setupTray();
+            startT();
+            EyeLogger.info("Main", "Startup complete");
+        } catch (Exception e) {
+            EyeLogger.error("Main", "Fatal error during startup", e);
+            System.exit(1);
+        }
     }
 
     public static void startT() {
@@ -83,8 +90,14 @@ public class Main {
 
     }
 
-    public static void shutdown () {
-        executor.shutdownNow();
-        System.exit(0);
+    public static void shutdown() {
+        EyeLogger.info("Main", "Shutdown requested — stopping executor and exiting");
+        try {
+            executor.shutdownNow();
+        } catch (Exception e) {
+            EyeLogger.error("Main", "Error while shutting down executor", e);
+        } finally {
+            System.exit(0);
+        }
     }
 }

--- a/src/main/java/com/eyesoft/Main.java
+++ b/src/main/java/com/eyesoft/Main.java
@@ -33,6 +33,7 @@ public class Main {
         }
 
         currentTask = executor.submit(() -> {
+            EyeLogger.info("Scheduler", "Break loop started — wait=" + waitSeconds + "s, break=" + breakSeconds + "s, notify=" + showNotification);
             try {
                 // First wait happens before the first break. We'll start with waiting.
                 while (!Thread.currentThread().isInterrupted()) {
@@ -71,9 +72,12 @@ public class Main {
                     }
                 }
             } catch (InterruptedException e) {
+                EyeLogger.info("Scheduler", "Break loop interrupted (normal on restart/shutdown)");
                 Thread.currentThread().interrupt();
             } catch (IOException e) {
-                e.printStackTrace();
+                EyeLogger.error("Scheduler", "Failed to launch ScreenBlocker process", e);
+            } catch (Exception e) {
+                EyeLogger.error("Scheduler", "Unexpected error in break loop", e);
             }
         });
 

--- a/src/main/java/com/eyesoft/Main.java
+++ b/src/main/java/com/eyesoft/Main.java
@@ -14,13 +14,14 @@ import java.util.prefs.Preferences;
 public class Main {
 
     static Preferences prefs = Preferences.userNodeForPackage(Main.class);
-    public static int waitSeconds = prefs.getInt("savedWaitTime", 30);
-    public static int breakSeconds = prefs.getInt("savedBreakTime", 20);
+    public static int waitSeconds  = prefs.getInt("savedWaitTime",  600);   // default 10 min
+    public static int breakSeconds = prefs.getInt("savedBreakTime", 20);    // default 20 sec
+    public static boolean showNotification = prefs.getBoolean("showNotification", true);
     
     private static ExecutorService executor = Executors.newSingleThreadExecutor();
     private static Future<?> currentTask;
 
-    void main() {
+    public static void main(String[] args) {
         AppTray.setupTray();
         startT();
     }
@@ -43,10 +44,14 @@ public class Main {
                         Thread.sleep(initialWait * 1000L);
                     }
 
-                    if (notifyAdvance > 0) {
+                    if (notifyAdvance > 0 && showNotification) {
                         if (AppTray.trayIcon != null) {
-                            AppTray.trayIcon.displayMessage("Upcoming Break", "Your break will start in " + notifyAdvance + " seconds.", TrayIcon.MessageType.INFO);
+                            AppTray.trayIcon.displayMessage("Upcoming Break",
+                                "Your break will start in " + notifyAdvance + " seconds.",
+                                TrayIcon.MessageType.INFO);
                         }
+                        Thread.sleep(notifyAdvance * 1000L);
+                    } else if (notifyAdvance > 0) {
                         Thread.sleep(notifyAdvance * 1000L);
                     }
 

--- a/src/main/java/com/eyesoft/ScreenBlocker.java
+++ b/src/main/java/com/eyesoft/ScreenBlocker.java
@@ -1,3 +1,5 @@
+package com.eyesoft;
+
 import javax.swing.*;
 import java.awt.*;
 

--- a/src/main/java/com/eyesoft/ScreenBlocker.java
+++ b/src/main/java/com/eyesoft/ScreenBlocker.java
@@ -3,25 +3,49 @@ package com.eyesoft;
 import javax.swing.*;
 import java.awt.*;
 
+/**
+ * ScreenBlocker — Full-screen break overlay window.
+ * Launched as a separate process by Main's scheduler.
+ * All errors logged with EyeLogger context.
+ */
 public class ScreenBlocker {
+
     public static void main(String[] args) {
-        JFrame frame = new JFrame();
+        EyeLogger.info("ScreenBlocker", "Break screen starting");
 
-        frame.setType(Window.Type.UTILITY);
-        // Windows Person Check - Rivindu
+        try {
+            JFrame frame = new JFrame();
+            frame.setType(Window.Type.UTILITY);
+            frame.setUndecorated(true);
+            frame.setAlwaysOnTop(true);
+            frame.getContentPane().setBackground(Color.BLACK);
+            frame.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 
-        frame.setUndecorated(true);
-        frame.setAlwaysOnTop(true);
-        frame.getContentPane().setBackground(Color.BLACK);
+            GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
 
-        GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
-        GraphicsDevice gd = ge.getDefaultScreenDevice();
+            try {
+                GraphicsDevice gd = ge.getDefaultScreenDevice();
 
-        if (gd.isFullScreenSupported()) {
-            gd.setFullScreenWindow(frame);
-        } else {
-            frame.setExtendedState(JFrame.MAXIMIZED_BOTH);
-            frame.setVisible(true);
+                if (gd.isFullScreenSupported()) {
+                    EyeLogger.info("ScreenBlocker", "Entering full-screen exclusive mode");
+                    gd.setFullScreenWindow(frame);
+                } else {
+                    EyeLogger.warn("ScreenBlocker", "Full-screen exclusive mode not supported — falling back to maximized window");
+                    frame.setExtendedState(JFrame.MAXIMIZED_BOTH);
+                    frame.setVisible(true);
+                }
+            } catch (Exception e) {
+                EyeLogger.error("ScreenBlocker", "Failed to set full-screen mode — falling back to maximized window", e);
+                frame.setExtendedState(JFrame.MAXIMIZED_BOTH);
+                frame.setVisible(true);
+            }
+
+            EyeLogger.info("ScreenBlocker", "Break screen displayed successfully");
+
+        } catch (HeadlessException e) {
+            EyeLogger.error("ScreenBlocker", "Cannot display break screen — headless environment detected", e);
+        } catch (Exception e) {
+            EyeLogger.error("ScreenBlocker", "Unexpected error while displaying break screen", e);
         }
     }
 }

--- a/src/main/java/com/eyesoft/Settings.java
+++ b/src/main/java/com/eyesoft/Settings.java
@@ -1,3 +1,5 @@
+package com.eyesoft;
+
 import javax.swing.*;
 import java.awt.*;
 import java.util.prefs.Preferences;

--- a/src/main/java/com/eyesoft/Settings.java
+++ b/src/main/java/com/eyesoft/Settings.java
@@ -2,7 +2,6 @@ package com.eyesoft;
 
 import javax.swing.*;
 import java.awt.*;
-import java.util.Hashtable;
 import java.util.prefs.Preferences;
 
 /**
@@ -16,7 +15,6 @@ public class Settings {
 
     // ── Dark palette ───────────────────────────────────────────────────────────
     private static final Color BG          = new Color(43, 43, 43);
-    private static final Color BG_SECTION  = new Color(50, 50, 50);
     private static final Color BG_TOOLBAR  = new Color(55, 55, 55);
     private static final Color BORDER_CLR  = new Color(70, 70, 70);
     private static final Color TEXT        = new Color(220, 220, 220);

--- a/src/main/java/com/eyesoft/Settings.java
+++ b/src/main/java/com/eyesoft/Settings.java
@@ -25,6 +25,7 @@ public class Settings {
 
     // ── Entry point ────────────────────────────────────────────────────────────
     public static void showWindow() {
+        EyeLogger.info("Settings", "Opening preferences window");
         if (frame != null && frame.isVisible()) {
             frame.toFront();
             return;
@@ -33,56 +34,66 @@ public class Settings {
         SwingUtilities.invokeLater(() -> {
             try {
                 UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
-            } catch (Exception ignored) {}
-
-            frame = new JFrame("EyeSoft Preferences");
-            frame.setType(Window.Type.UTILITY);
-            frame.setSize(560, 620);
-            frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-            frame.setLocationRelativeTo(null);
-            frame.setAlwaysOnTop(true);
-            frame.setResizable(false);
-            frame.getContentPane().setBackground(BG);
-            frame.setLayout(new BorderLayout());
-
-            // ── Toolbar tabs
-            JPanel toolbar       = buildToolbar();
-            JPanel cardContainer = new JPanel(new CardLayout());
-            cardContainer.setBackground(BG);
-
-            JPanel schedulePanel = buildSchedulePanel();
-            JPanel aboutPanel    = buildAboutPanel();
-            cardContainer.add(schedulePanel, "Schedule");
-            cardContainer.add(aboutPanel,    "About");
-
-            CardLayout cards = (CardLayout) cardContainer.getLayout();
-
-            // Wire tab buttons from toolbar
-            for (Component c : toolbar.getComponents()) {
-                if (c instanceof JButton btn) {
-                    btn.addActionListener(e -> {
-                        cards.show(cardContainer, btn.getActionCommand());
-                        // Active highlight
-                        for (Component tb : toolbar.getComponents()) {
-                            if (tb instanceof JButton b) b.setBackground(BG_TOOLBAR);
-                        }
-                        btn.setBackground(BG.darker());
-                    });
-                }
+            } catch (Exception e) {
+                EyeLogger.warn("Settings", "Failed to set cross-platform LAF: " + e.getMessage());
             }
 
-            // Pre-select Schedule tab
-            for (Component c : toolbar.getComponents()) {
-                if (c instanceof JButton b && "Schedule".equals(b.getActionCommand())) {
-                    b.setBackground(BG.darker());
-                    break;
-                }
-            }
-            cards.show(cardContainer, "Schedule");
+            try {
+                frame = new JFrame("EyeSoft Preferences");
+                frame.setType(Window.Type.UTILITY);
+                frame.setSize(560, 620);
+                frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+                frame.setLocationRelativeTo(null);
+                frame.setAlwaysOnTop(true);
+                frame.setResizable(false);
+                frame.getContentPane().setBackground(BG);
+                frame.setLayout(new BorderLayout());
 
-            frame.add(toolbar, BorderLayout.NORTH);
-            frame.add(cardContainer, BorderLayout.CENTER);
-            frame.setVisible(true);
+                // ── Toolbar tabs
+                JPanel toolbar       = buildToolbar();
+                JPanel cardContainer = new JPanel(new CardLayout());
+                cardContainer.setBackground(BG);
+
+                JPanel schedulePanel = buildSchedulePanel();
+                JPanel aboutPanel    = buildAboutPanel();
+                cardContainer.add(schedulePanel, "Schedule");
+                cardContainer.add(aboutPanel,    "About");
+
+                CardLayout cards = (CardLayout) cardContainer.getLayout();
+
+                // Wire tab buttons from toolbar
+                for (Component c : toolbar.getComponents()) {
+                    if (c instanceof JButton btn) {
+                        btn.addActionListener(e -> {
+                            try {
+                                cards.show(cardContainer, btn.getActionCommand());
+                                for (Component tb : toolbar.getComponents()) {
+                                    if (tb instanceof JButton b) b.setBackground(BG_TOOLBAR);
+                                }
+                                btn.setBackground(BG.darker());
+                            } catch (Exception ex) {
+                                EyeLogger.error("Settings", "Error switching to tab: " + btn.getActionCommand(), ex);
+                            }
+                        });
+                    }
+                }
+
+                // Pre-select Schedule tab
+                for (Component c : toolbar.getComponents()) {
+                    if (c instanceof JButton b && "Schedule".equals(b.getActionCommand())) {
+                        b.setBackground(BG.darker());
+                        break;
+                    }
+                }
+                cards.show(cardContainer, "Schedule");
+
+                frame.add(toolbar, BorderLayout.NORTH);
+                frame.add(cardContainer, BorderLayout.CENTER);
+                frame.setVisible(true);
+                EyeLogger.info("Settings", "Preferences window opened successfully");
+            } catch (Exception e) {
+                EyeLogger.error("Settings", "Failed to build or show preferences window", e);
+            }
         });
     }
 
@@ -136,8 +147,13 @@ public class Settings {
         // Notification checkbox
         JCheckBox notifCB = makeCheckBox("Show notification before break starts", Main.showNotification);
         notifCB.addActionListener(e -> {
-            Main.showNotification = notifCB.isSelected();
-            saveBoolean("showNotification", Main.showNotification);
+            try {
+                Main.showNotification = notifCB.isSelected();
+                saveBoolean("showNotification", Main.showNotification);
+                EyeLogger.info("Settings", "Notification pref changed to: " + Main.showNotification);
+            } catch (Exception ex) {
+                EyeLogger.error("Settings", "Failed to save notification preference", ex);
+            }
         });
         root.add(notifCB);
         root.add(Box.createVerticalStrut(18));
@@ -170,15 +186,21 @@ public class Settings {
 
         JButton restoreBtn = makeActionButton("Restore defaults");
         restoreBtn.addActionListener(e -> {
-            Main.breakSeconds = 20;
-            Main.waitSeconds  = 600;
-            Main.showNotification = true;
-            saveInt("savedBreakTime",   20);
-            saveInt("savedWaitTime",    600);
-            saveBoolean("showNotification", true);
-            Main.startT();
-            frame.dispose();
-            showWindow();  // re-open refreshed
+            try {
+                EyeLogger.info("Settings", "Restoring defaults");
+                Main.breakSeconds     = 20;
+                Main.waitSeconds      = 600;
+                Main.showNotification = true;
+                saveInt("savedBreakTime",       20);
+                saveInt("savedWaitTime",        600);
+                saveBoolean("showNotification", true);
+                Main.startT();
+                frame.dispose();
+                showWindow();
+                EyeLogger.info("Settings", "Defaults restored successfully");
+            } catch (Exception ex) {
+                EyeLogger.error("Settings", "Failed to restore defaults", ex);
+            }
         });
         root.add(restoreBtn);
 
@@ -230,7 +252,11 @@ public class Settings {
 
         s.addChangeListener(e -> {
             if (!s.getValueIsAdjusting()) {
-                onChange.accept(s.getValue());
+                try {
+                    onChange.accept(s.getValue());
+                } catch (Exception ex) {
+                    EyeLogger.error("Settings", "Failed to apply slider value: " + s.getValue(), ex);
+                }
             }
         });
         return s;

--- a/src/main/java/com/eyesoft/Settings.java
+++ b/src/main/java/com/eyesoft/Settings.java
@@ -2,83 +2,322 @@ package com.eyesoft;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.Hashtable;
 import java.util.prefs.Preferences;
 
+/**
+ * Settings — EyeSoft Preferences Window
+ * Dark-themed with tabs: Schedule | About
+ * Implements GitHub issue #2:
+ *   - Schedule tab with Short Break (adjustable time + notification toggle)
+ *   - Waiting Time (adjustable interval)
+ */
 public class Settings {
+
+    // ── Dark palette ───────────────────────────────────────────────────────────
+    private static final Color BG          = new Color(43, 43, 43);
+    private static final Color BG_SECTION  = new Color(50, 50, 50);
+    private static final Color BG_TOOLBAR  = new Color(55, 55, 55);
+    private static final Color BORDER_CLR  = new Color(70, 70, 70);
+    private static final Color TEXT        = new Color(220, 220, 220);
+    private static final Color TEXT_MUTED  = new Color(155, 155, 155);
+    private static final Color ORANGE      = new Color(220, 130, 50);   // slider thumb
 
     private static JFrame frame = null;
 
+    // ── Entry point ────────────────────────────────────────────────────────────
     public static void showWindow() {
         if (frame != null && frame.isVisible()) {
             frame.toFront();
             return;
         }
 
-        frame = new JFrame("Settings");
-
-        frame.setType(Window.Type.UTILITY);
-        // Hide from Windows
-        //Windows Person Fix It Pleaseeeee
-
-        frame.setSize(300, 150);
-
-
-
-        // Do Not Kill Background Task
-        frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-        frame.setLayout(new FlowLayout(FlowLayout.CENTER, 10, 20));
-        frame.setLocationRelativeTo(null);
-        frame.setAlwaysOnTop(true);
-
-        JTabbedPane tabbedPane = new JTabbedPane();
-        JPanel timingPanel = new JPanel(new GridLayout(3, 2, 10, 10));
-        timingPanel.setBorder(BorderFactory.createEmptyBorder(20, 20, 20, 20));
-
-        JLabel waitLabel = new JLabel("Wait Time (seconds):");
-        JTextField waitTimeField = new JTextField(String.valueOf(Main.waitSeconds), 5);
-
-        JLabel breakLabel = new JLabel("Break Time (seconds):");
-        JTextField breakTimeField = new JTextField(String.valueOf(Main.breakSeconds), 5);
-
-        JButton saveButton = new JButton("Save");
-        saveButton.addActionListener(e -> {
+        SwingUtilities.invokeLater(() -> {
             try {
-                int newWait = Integer.parseInt(waitTimeField.getText().trim());
-                int newBreak = Integer.parseInt(breakTimeField.getText().trim());
+                UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
+            } catch (Exception ignored) {}
 
-                Main.waitSeconds = newWait;
-                Main.breakSeconds = newBreak;
+            frame = new JFrame("EyeSoft Preferences");
+            frame.setType(Window.Type.UTILITY);
+            frame.setSize(560, 620);
+            frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+            frame.setLocationRelativeTo(null);
+            frame.setAlwaysOnTop(true);
+            frame.setResizable(false);
+            frame.getContentPane().setBackground(BG);
+            frame.setLayout(new BorderLayout());
 
-                Preferences prefs = Preferences.userNodeForPackage(Main.class);
-                prefs.putInt("savedWaitTime", newWait);
-                prefs.putInt("savedBreakTime", newBreak);
-                Main.startT();
+            // ── Toolbar tabs
+            JPanel toolbar       = buildToolbar();
+            JPanel cardContainer = new JPanel(new CardLayout());
+            cardContainer.setBackground(BG);
 
-                frame.dispose();
-            } catch (NumberFormatException ex) {
-                JOptionPane.showMessageDialog(frame, "Please enter valid numbers for both fields.", "Input Error", JOptionPane.ERROR_MESSAGE);
-                //Setting Error
+            JPanel schedulePanel = buildSchedulePanel();
+            JPanel aboutPanel    = buildAboutPanel();
+            cardContainer.add(schedulePanel, "Schedule");
+            cardContainer.add(aboutPanel,    "About");
+
+            CardLayout cards = (CardLayout) cardContainer.getLayout();
+
+            // Wire tab buttons from toolbar
+            for (Component c : toolbar.getComponents()) {
+                if (c instanceof JButton btn) {
+                    btn.addActionListener(e -> {
+                        cards.show(cardContainer, btn.getActionCommand());
+                        // Active highlight
+                        for (Component tb : toolbar.getComponents()) {
+                            if (tb instanceof JButton b) b.setBackground(BG_TOOLBAR);
+                        }
+                        btn.setBackground(BG.darker());
+                    });
+                }
+            }
+
+            // Pre-select Schedule tab
+            for (Component c : toolbar.getComponents()) {
+                if (c instanceof JButton b && "Schedule".equals(b.getActionCommand())) {
+                    b.setBackground(BG.darker());
+                    break;
+                }
+            }
+            cards.show(cardContainer, "Schedule");
+
+            frame.add(toolbar, BorderLayout.NORTH);
+            frame.add(cardContainer, BorderLayout.CENTER);
+            frame.setVisible(true);
+        });
+    }
+
+    // ── Toolbar ────────────────────────────────────────────────────────────────
+    private static JPanel buildToolbar() {
+        JPanel bar = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+        bar.setBackground(BG_TOOLBAR);
+        bar.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, BORDER_CLR));
+        bar.setPreferredSize(new Dimension(560, 72));
+        bar.add(makeTabBtn("⚙", "Settings"));
+        bar.add(makeTabBtn("⏰", "Schedule"));
+        bar.add(makeTabBtn("ℹ", "About"));
+        return bar;
+    }
+
+    private static JButton makeTabBtn(String icon, String label) {
+        JButton b = new JButton("<html><center><font size='5'>" + icon + "</font><br>"
+                + "<font size='2'>" + label + "</font></center></html>");
+        b.setActionCommand(label);
+        b.setPreferredSize(new Dimension(90, 72));
+        b.setForeground(TEXT);
+        b.setBackground(BG_TOOLBAR);
+        b.setBorderPainted(false);
+        b.setFocusPainted(false);
+        b.setOpaque(true);
+        b.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+        return b;
+    }
+
+    // ── Schedule tab ───────────────────────────────────────────────────────────
+    private static JPanel buildSchedulePanel() {
+        JPanel root = new JPanel();
+        root.setLayout(new BoxLayout(root, BoxLayout.Y_AXIS));
+        root.setBackground(BG);
+        root.setBorder(BorderFactory.createEmptyBorder(16, 20, 16, 20));
+
+        // ── Short Break section
+        root.add(buildSectionHeader("Short Break"));
+        root.add(Box.createVerticalStrut(6));
+        root.add(styledLabel("Short breaks help rest your eyes and reduce screen fatigue.", TEXT_MUTED, 12));
+        root.add(Box.createVerticalStrut(14));
+
+        // Break duration slider (5s – 300s)
+        JSlider breakSlider = makeSlider(5, 300, Main.breakSeconds, 1, s -> {
+            Main.breakSeconds = s;
+            saveInt("savedBreakTime", s);
+        });
+        root.add(sliderRow("Break for:", breakSlider, v -> v + " seconds"));
+        root.add(Box.createVerticalStrut(10));
+
+        // Notification checkbox
+        JCheckBox notifCB = makeCheckBox("Show notification before break starts", Main.showNotification);
+        notifCB.addActionListener(e -> {
+            Main.showNotification = notifCB.isSelected();
+            saveBoolean("showNotification", Main.showNotification);
+        });
+        root.add(notifCB);
+        root.add(Box.createVerticalStrut(18));
+
+        // Divider
+        root.add(divider());
+        root.add(Box.createVerticalStrut(18));
+
+        // ── Waiting Time section
+        root.add(buildSectionHeader("Waiting Time"));
+        root.add(Box.createVerticalStrut(6));
+        root.add(styledLabel("How long to wait between breaks.", TEXT_MUTED, 12));
+        root.add(Box.createVerticalStrut(14));
+
+        // Wait interval slider (60s – 7200s)
+        JSlider waitSlider = makeSlider(60, 7200, Main.waitSeconds, 60, s -> {
+            Main.waitSeconds = s;
+            saveInt("savedWaitTime", s);
+            Main.startT();  // restart timer with new wait
+        });
+        root.add(sliderRow("Every:", waitSlider, v -> {
+            if (v < 60) return v + " seconds";
+            return (v / 60) + " minute" + (v / 60 == 1 ? "" : "s");
+        }));
+        root.add(Box.createVerticalStrut(24));
+
+        // Divider + Restore defaults
+        root.add(divider());
+        root.add(Box.createVerticalStrut(16));
+
+        JButton restoreBtn = makeActionButton("Restore defaults");
+        restoreBtn.addActionListener(e -> {
+            Main.breakSeconds = 20;
+            Main.waitSeconds  = 600;
+            Main.showNotification = true;
+            saveInt("savedBreakTime",   20);
+            saveInt("savedWaitTime",    600);
+            saveBoolean("showNotification", true);
+            Main.startT();
+            frame.dispose();
+            showWindow();  // re-open refreshed
+        });
+        root.add(restoreBtn);
+
+        return root;
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    @FunctionalInterface
+    interface IntConsumer { void accept(int value); }
+    @FunctionalInterface
+    interface Labeller    { String label(int value); }
+
+    /** Builds a row: [label] [slider] [value label] */
+    private static JPanel sliderRow(String prefix, JSlider slider, Labeller labeller) {
+        JLabel valueLabel = styledLabel(labeller.label(slider.getValue()), TEXT, 13);
+        valueLabel.setPreferredSize(new Dimension(90, 20));
+
+        slider.addChangeListener(e -> valueLabel.setText(labeller.label(slider.getValue())));
+
+        JLabel prefixLabel = styledLabel(prefix, TEXT, 13);
+        prefixLabel.setPreferredSize(new Dimension(80, 20));
+
+        JPanel row = new JPanel(new BorderLayout(8, 0));
+        row.setBackground(BG);
+        row.setMaximumSize(new Dimension(Integer.MAX_VALUE, 40));
+        row.setAlignmentX(Component.LEFT_ALIGNMENT);
+        row.add(prefixLabel, BorderLayout.WEST);
+        row.add(slider,      BorderLayout.CENTER);
+        row.add(valueLabel,  BorderLayout.EAST);
+        return row;
+    }
+
+    private static JSlider makeSlider(int min, int max, int value, int tickSpacing, IntConsumer onChange) {
+        JSlider s = new JSlider(min, max, value);
+        s.setBackground(BG);
+        s.setForeground(TEXT);
+        s.setPaintTicks(true);
+        s.setPaintLabels(false);
+        s.setMinorTickSpacing(tickSpacing);
+        s.setOpaque(false);
+        // Orange thumb via UI defaults
+        UIManager.put("Slider.thumb", ORANGE);
+
+        // Hashtable<Integer, JLabel> labels = new Hashtable<>();
+        // labels.put(min, styledLabel(String.valueOf(min), TEXT_MUTED, 10));
+        // labels.put(max, styledLabel(String.valueOf(max), TEXT_MUTED, 10));
+        // s.setLabelTable(labels);
+
+        s.addChangeListener(e -> {
+            if (!s.getValueIsAdjusting()) {
+                onChange.accept(s.getValue());
             }
         });
+        return s;
+    }
 
-        timingPanel.add(waitLabel);
-        timingPanel.add(waitTimeField);
-        timingPanel.add(breakLabel);
-        timingPanel.add(breakTimeField);
-        timingPanel.add(new JLabel("")); // Empty cell for alignment
-        timingPanel.add(saveButton);
+    private static JCheckBox makeCheckBox(String text, boolean selected) {
+        JCheckBox cb = new JCheckBox(text, selected);
+        cb.setBackground(BG);
+        cb.setForeground(TEXT);
+        cb.setFocusPainted(false);
+        cb.setFont(new Font("Dialog", Font.PLAIN, 13));
+        cb.setAlignmentX(Component.LEFT_ALIGNMENT);
+        return cb;
+    }
 
-        JPanel aboutPanel = new JPanel(new BorderLayout());
+    private static JLabel styledLabel(String text, Color color, int size) {
+        JLabel l = new JLabel(text);
+        l.setForeground(color);
+        l.setFont(new Font("Dialog", Font.PLAIN, size));
+        l.setAlignmentX(Component.LEFT_ALIGNMENT);
+        return l;
+    }
 
-        JLabel aboutLabel = new JLabel("<html><center><b>EyeSoft Blocker</b><br>Take care of your eyes!<br>Version 1.0</center></html>", SwingConstants.CENTER);
-        aboutPanel.add(aboutLabel, BorderLayout.CENTER);
+    private static JPanel buildSectionHeader(String title) {
+        JLabel lbl = new JLabel(title);
+        lbl.setForeground(TEXT);
+        lbl.setFont(new Font("Dialog", Font.BOLD, 14));
+        JPanel p = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+        p.setBackground(BG);
+        p.setAlignmentX(Component.LEFT_ALIGNMENT);
+        p.add(lbl);
+        return p;
+    }
 
+    private static JSeparator divider() {
+        JSeparator sep = new JSeparator();
+        sep.setForeground(BORDER_CLR);
+        sep.setMaximumSize(new Dimension(Integer.MAX_VALUE, 1));
+        sep.setAlignmentX(Component.LEFT_ALIGNMENT);
+        return sep;
+    }
 
-        tabbedPane.addTab("Timing", timingPanel);
-        tabbedPane.addTab("About", aboutPanel);
+    private static JButton makeActionButton(String text) {
+        JButton b = new JButton(text);
+        b.setAlignmentX(Component.LEFT_ALIGNMENT);
+        b.setBackground(new Color(70, 70, 70));
+        b.setForeground(TEXT);
+        b.setBorderPainted(false);
+        b.setFocusPainted(false);
+        b.setOpaque(true);
+        b.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+        return b;
+    }
 
+    private static void saveInt(String key, int value) {
+        Preferences.userNodeForPackage(Main.class).putInt(key, value);
+    }
 
-        frame.add(tabbedPane);
-        frame.setVisible(true);
+    private static void saveBoolean(String key, boolean value) {
+        Preferences.userNodeForPackage(Main.class).putBoolean(key, value);
+    }
+
+    // ── About tab ──────────────────────────────────────────────────────────────
+    private static JPanel buildAboutPanel() {
+        JPanel p = new JPanel(new GridBagLayout());
+        p.setBackground(BG);
+
+        GridBagConstraints g = new GridBagConstraints();
+        g.gridx = 0; g.insets = new Insets(8, 0, 8, 0);
+
+        JLabel title = new JLabel("👁  EyeSoft");
+        title.setFont(new Font("Dialog", Font.BOLD, 22));
+        title.setForeground(TEXT);
+
+        JLabel sub = new JLabel("Take care of your eyes.");
+        sub.setFont(new Font("Dialog", Font.PLAIN, 14));
+        sub.setForeground(TEXT_MUTED);
+
+        JLabel ver = new JLabel("Version 1.1");
+        ver.setFont(new Font("Dialog", Font.PLAIN, 12));
+        ver.setForeground(TEXT_MUTED);
+
+        g.gridy = 0; p.add(title, g);
+        g.gridy = 1; p.add(sub,   g);
+        g.gridy = 2; p.add(ver,   g);
+        return p;
     }
 }


### PR DESCRIPTION
## Overview

Closes #2

This PR implements the Schedule function page in Settings as described in issue #2, allowing users to adjust break duration, waiting time between breaks, and toggle upcoming break notifications.

---

## Changes

### Schedule Tab (Settings)
- Added a dark-themed **Schedule** tab in the Settings preferences window  
- **Short Break** section:
  - Slider to adjust break duration (5 seconds → 5 minutes)
  - Checkbox: *"Show notification before break starts"*
- **Waiting Time** section:
  - Slider to adjust interval between breaks (1 minute → 2 hours)
  - Label auto-reformats to minutes for readability
- **Restore Defaults** button — resets to 20s break / 10 min wait
- All settings persist across restarts via `java.util.prefs.Preferences`

###  Pre-Break Notification
- Tray notification fires N seconds before a break (configurable, defaults to 10s)
- Notification can be toggled off from the Schedule tab

### 📁 Project Restructure
- Moved all sources into standard `src/main/java/com/eyesoft/` package layout
- Added `package com.eyesoft;` declarations to all classes
- Added `*.class` to `.gitignore` to stop tracking compiled bytecode

###  EyeLogger — Centralized Error Logging
- New `EyeLogger.java` — context-aware logger with rotating file output (`~/Library/Logs/EyeSoft.log`)
- Applied across **all** files and **all** functions:
  - `Main` — startup, scheduler loop start/interrupt/failure, shutdown
  - `AppTray` — tray setup, menu actions, double-click
  - `ScreenBlocker` — full-screen mode, fallback, headless detection
  - `Settings` — window construction, all action listeners, slider changes, preference saves

###  Bug Fix
- Fixed `void main()` that was an instance method instead of `public static void main(String[] args)` — the app was silently doing nothing on launch

---

## Testing
- Compiled successfully with `javac -d out src/main/java/com/eyesoft/*.java`
- Manually verified:
  - Settings window opens from tray
  - Sliders update live and persist after restart
  - Notification fires before break
  - Break screen appears for configured duration and then disappears
